### PR TITLE
Added `Macro.peek_code/1` and `~>>` no longer reevaluates expression

### DIFF
--- a/lib/bunch.ex
+++ b/lib/bunch.ex
@@ -292,7 +292,7 @@ defmodule Bunch do
   defmacro expr ~>> mapper_clauses do
     default =
       quote do
-        _ -> unquote(expr)
+        default_result -> default_result
       end
 
     quote do

--- a/lib/bunch/code.ex
+++ b/lib/bunch/code.ex
@@ -1,0 +1,17 @@
+defmodule Bunch.Code do
+  @moduledoc """
+  A bunch of helper functions for code compilation, code evaluation, and code loading.
+  """
+
+  @doc """
+  Takes a code block, expands macros inside and pretty prints it.
+  """
+  defmacro peek_code(do: block) do
+    block
+    |> Bunch.Macro.expand_deep(__CALLER__)
+    |> Macro.to_string()
+    |> IO.puts()
+
+    block
+  end
+end

--- a/lib/bunch/macro.ex
+++ b/lib/bunch/macro.ex
@@ -82,4 +82,17 @@ defmodule Bunch.Macro do
 
     ast
   end
+
+  @doc """
+  Takes a code block, expands macros inside and pretty prints it.
+  """
+  defmacro peek_code(do: block) do
+    Macro.prewalk(block, fn tree -> Macro.expand(tree, __ENV__) end)
+    |> Macro.to_string()
+    |> IO.puts()
+
+    quote do
+      unquote(block)
+    end
+  end
 end

--- a/lib/bunch/macro.ex
+++ b/lib/bunch/macro.ex
@@ -90,18 +90,4 @@ defmodule Bunch.Macro do
   it out for more information and examples.
   """
   def expand_deep(ast, env), do: Macro.prewalk(ast, fn tree -> Macro.expand(tree, env) end)
-
-  @doc """
-  Takes a code block, expands macros inside and pretty prints it.
-  """
-  defmacro peek_code(do: block) do
-    block
-    |> expand_deep(__CALLER__)
-    |> Macro.to_string()
-    |> IO.puts()
-
-    quote do
-      unquote(block)
-    end
-  end
 end

--- a/lib/bunch/macro.ex
+++ b/lib/bunch/macro.ex
@@ -84,10 +84,19 @@ defmodule Bunch.Macro do
   end
 
   @doc """
+  Receives an AST and traverses it expanding all the nodes.
+
+  This function uses `Macro.expand/2` under the hood. Check
+  it out for more information and examples.
+  """
+  def expand_deep(ast, env), do: Macro.prewalk(ast, fn tree -> Macro.expand(tree, env) end)
+
+  @doc """
   Takes a code block, expands macros inside and pretty prints it.
   """
   defmacro peek_code(do: block) do
-    Macro.prewalk(block, fn tree -> Macro.expand(tree, __ENV__) end)
+    block
+    |> expand_deep(__CALLER__)
     |> Macro.to_string()
     |> IO.puts()
 


### PR DESCRIPTION
Added function that makes developing and debugging macros easier by pretty printing expanded ast.