### PR TITLE
Use case instead of with

### DIFF
--- a/lib/bunch.ex
+++ b/lib/bunch.ex
@@ -245,8 +245,7 @@ defmodule Bunch do
             "Label `#{inspect(label)}` not present in withl else clauses"
             |> raise_compile_error(caller, meta)
 
-        args = [clause, [do: acc] ++ [else: label_else_clauses]]
-        {:with, meta, args}
+        {:with, meta, [clause, [do: acc, else: label_else_clauses]]}
 
       {_label, clause}, acc ->
         quote do


### PR DESCRIPTION
This is really minor, but I did some benchmarks and found that (at least on my x86_64 Mac) `case` is slightly faster than `with`. Since these functions are run in buffer processing in `membrane_core`, I thought that shaving off some microseconds here might have some small performance improvement of core.