### PR TITLE
Repair an indentation issue with then_if example in docs

### DIFF
--- a/lib/bunch.ex
+++ b/lib/bunch.ex
@@ -455,14 +455,16 @@ defmodule Bunch do
   an identity function otherwise.
 
   ## Examples
-    iex> use #{inspect(__MODULE__)}
-    iex> then_if(1, false, & &1 + 1)
-    1
-    iex> then_if(1, true, & &1 + 1)
-    2
-    iex> arg = 1
-    iex> arg |> then_if(not is_list(arg), fn arg -> [arg] end) |> Enum.map(&(&1*2))
-    [2]
+
+      iex> use #{inspect(__MODULE__)}
+      iex> then_if(1, false, & &1 + 1)
+      1
+      iex> then_if(1, true, & &1 + 1)
+      2
+      iex> arg = 1
+      iex> arg |> then_if(not is_list(arg), fn arg -> [arg] end) |> Enum.map(&(&1*2))
+      [2]
+
   """
   @spec then_if(x, condition :: boolean(), f :: (x -> y)) :: y when x: any(), y: any()
   def then_if(x, condition, f) do


### PR DESCRIPTION
The documentation has been generated improperly (just take a look: https://hexdocs.pm/bunch/Bunch.html#then_if/3) and this PR fixes it